### PR TITLE
Feature/fix convention scanning

### DIFF
--- a/Main/NUnit.Extension.DependencyInjection.Unity.Tests/ConventionMappingTypeDiscovererTests.cs
+++ b/Main/NUnit.Extension.DependencyInjection.Unity.Tests/ConventionMappingTypeDiscovererTests.cs
@@ -26,7 +26,6 @@ namespace NUnit.Extension.DependencyInjection.Unity.Tests
       }
     }
     
-    
     [Test]
     public void Discover_excludes_types_decorated_with_NUnitExcludeFromAutoScanAttribute_from_ioc_container_registration()
     {
@@ -40,6 +39,19 @@ namespace NUnit.Extension.DependencyInjection.Unity.Tests
           $"Found a registration which mapped type {typeof(IFoo).FullName} to {typeof(Foo).FullName}");
       }
     }
-    
+
+    [Test]
+    public void Discover_excludes_interfaces_that_do_not_have_corresponding_concrete_implementations()
+    {
+      using (var container = new UnityContainer())
+      {
+        var discoverer = new ConventionMappingTypeDiscoverer();
+        discoverer.Discover(container);
+        Assert.That(
+          container.Registrations.Any(r => r.RegisteredType.IsAbstract && r.MappedToType is null),
+          Is.False,
+          "Found a registration for a type without a concrete implementation");
+      }
+    }
   }
 }

--- a/Main/NUnit.Extension.DependencyInjection.Unity.Tests/ConventionMappingTypeDiscovererTests.cs
+++ b/Main/NUnit.Extension.DependencyInjection.Unity.Tests/ConventionMappingTypeDiscovererTests.cs
@@ -53,5 +53,18 @@ namespace NUnit.Extension.DependencyInjection.Unity.Tests
           "Found a registration for a type without a concrete implementation");
       }
     }
+    
+    [Test]
+    public void Discover_can_resolve_classes_that_do_not_implement_any_interfaces()
+    {
+      using (var container = new UnityContainer())
+      {
+        var discoverer = new ConventionMappingTypeDiscoverer();
+        discoverer.Discover(container);
+        var resolved = container.Resolve<ClassThatImplementsNoInterface>();
+        Assert.That(resolved, Is.Not.Null);
+        Assert.That(resolved, Is.InstanceOf<ClassThatImplementsNoInterface>());
+      }
+    }
   }
 }

--- a/Main/NUnit.Extension.DependencyInjection.Unity.Tests/ConventionMappingTypeDiscovererTests.cs
+++ b/Main/NUnit.Extension.DependencyInjection.Unity.Tests/ConventionMappingTypeDiscovererTests.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT license. See LICENSE file alongside the solution file for full license information.
 
 using System.Linq;
+using NUnit.Extension.DependencyInjection.Unity.Tests.SampleTypes;
 using NUnit.Framework;
 using Unity;
 
 namespace NUnit.Extension.DependencyInjection.Unity.Tests
 {
+  
   [TestFixture]
   public class ConventionMappingTypeDiscovererTests
   {
@@ -23,5 +25,21 @@ namespace NUnit.Extension.DependencyInjection.Unity.Tests
           $"No registration of type {typeof(ITestSettings).FullName} that maps to {typeof(TestSettings).FullName}");
       }
     }
+    
+    
+    [Test]
+    public void Discover_excludes_types_decorated_with_NUnitExcludeFromAutoScanAttribute_from_ioc_container_registration()
+    {
+      using (var container = new UnityContainer())
+      {
+        var discoverer = new ConventionMappingTypeDiscoverer();
+        discoverer.Discover(container);
+        Assert.That(
+          container.Registrations.Any(r => r.RegisteredType == typeof(IFoo) && r.MappedToType == typeof(Foo)),
+          Is.False,
+          $"Found a registration which mapped type {typeof(IFoo).FullName} to {typeof(Foo).FullName}");
+      }
+    }
+    
   }
 }

--- a/Main/NUnit.Extension.DependencyInjection.Unity.Tests/SampleTypes/ClassThatImplementsNoInterface.cs
+++ b/Main/NUnit.Extension.DependencyInjection.Unity.Tests/SampleTypes/ClassThatImplementsNoInterface.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Kaleb Pederson Software LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file alongside the solution file for full license information.
+
+namespace NUnit.Extension.DependencyInjection.Unity.Tests.SampleTypes
+{
+  public class ClassThatImplementsNoInterface
+  {
+  }
+}

--- a/Main/NUnit.Extension.DependencyInjection.Unity.Tests/SampleTypes/Foo.cs
+++ b/Main/NUnit.Extension.DependencyInjection.Unity.Tests/SampleTypes/Foo.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Kaleb Pederson Software LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file alongside the solution file for full license information.
+
+namespace NUnit.Extension.DependencyInjection.Unity.Tests.SampleTypes
+{
+  [NUnitExcludeFromAutoScan]
+  public class Foo : IFoo {}
+}

--- a/Main/NUnit.Extension.DependencyInjection.Unity.Tests/SampleTypes/IFoo.cs
+++ b/Main/NUnit.Extension.DependencyInjection.Unity.Tests/SampleTypes/IFoo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Kaleb Pederson Software LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file alongside the solution file for full license information.
+
+namespace NUnit.Extension.DependencyInjection.Unity.Tests.SampleTypes
+{
+  public interface IFoo {}
+}

--- a/Main/NUnit.Extension.DependencyInjection.Unity.Tests/SampleTypes/IHaveNoConcreteImplementation.cs
+++ b/Main/NUnit.Extension.DependencyInjection.Unity.Tests/SampleTypes/IHaveNoConcreteImplementation.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Kaleb Pederson Software LLC. All rights reserved.
+// Licensed under the MIT license. See LICENSE file alongside the solution file for full license information.
+
+namespace NUnit.Extension.DependencyInjection.Unity.Tests.SampleTypes
+{
+  public interface IHaveNoConcreteImplementation {}
+}

--- a/Main/NUnit.Extension.DependencyInjection.Unity.Tests/SampleTypes/IOtherDependency.cs
+++ b/Main/NUnit.Extension.DependencyInjection.Unity.Tests/SampleTypes/IOtherDependency.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Kaleb Pederson Software LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file alongside the solution file for full license information.
 
-namespace NUnit.Extension.DependencyInjection.Unity.Tests
+namespace NUnit.Extension.DependencyInjection.Unity.Tests.SampleTypes
 {
   public interface IOtherDependency
   {

--- a/Main/NUnit.Extension.DependencyInjection.Unity.Tests/SampleTypes/ITestSettings.cs
+++ b/Main/NUnit.Extension.DependencyInjection.Unity.Tests/SampleTypes/ITestSettings.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 
-namespace NUnit.Extension.DependencyInjection.Unity.Tests
+namespace NUnit.Extension.DependencyInjection.Unity.Tests.SampleTypes
 {
   public interface ITestSettings
   {

--- a/Main/NUnit.Extension.DependencyInjection.Unity.Tests/SampleTypes/OtherDependency.cs
+++ b/Main/NUnit.Extension.DependencyInjection.Unity.Tests/SampleTypes/OtherDependency.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Kaleb Pederson Software LLC. All rights reserved.
 // Licensed under the MIT license. See LICENSE file alongside the solution file for full license information.
 
-namespace NUnit.Extension.DependencyInjection.Unity.Tests
+namespace NUnit.Extension.DependencyInjection.Unity.Tests.SampleTypes
 {
   public class OtherDependency : IOtherDependency
   {

--- a/Main/NUnit.Extension.DependencyInjection.Unity.Tests/SampleTypes/TestSettings.cs
+++ b/Main/NUnit.Extension.DependencyInjection.Unity.Tests/SampleTypes/TestSettings.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 
-namespace NUnit.Extension.DependencyInjection.Unity.Tests
+namespace NUnit.Extension.DependencyInjection.Unity.Tests.SampleTypes
 {
   public class TestSettings : ITestSettings
   {

--- a/Main/NUnit.Extension.DependencyInjection.Unity/NUnit.Extension.DependencyInjection.Unity.csproj
+++ b/Main/NUnit.Extension.DependencyInjection.Unity/NUnit.Extension.DependencyInjection.Unity.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net45;net46;net47;netstandard20</TargetFrameworks>
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
     <Authors>Kaleb Pederson</Authors>
     <Company>Kaleb Pederson Software LLC</Company>
     <Description>Enables dependency injection within NUnit using the Unity inversion of control container.</Description>
@@ -14,7 +14,7 @@
     <PackageTags>nunit dependency-injection unity</PackageTags>
     <IsTestProject>false</IsTestProject>
     <AssemblyVersion>0.5.0.0</AssemblyVersion>
-    <FileVersion>0.5.0.0</FileVersion>
+    <FileVersion>0.5.1.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReleaseNotes>
       Add support for specifying a ManualRegistrarTypeDiscoverer.

--- a/Main/NUnit.Extension.DependencyInjection.dotSettings
+++ b/Main/NUnit.Extension.DependencyInjection.dotSettings
@@ -1,0 +1,3 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+  <s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">// Copyright (c) Kaleb Pederson Software LLC. All rights reserved.&#xDLicensed under the MIT license. See LICENSE file alongside the solution file for full license information.&#xD</s:String>
+</wpf:ResourceDictionary>

--- a/Validation/ConventionMappingTypeDiscovererTests/ConventionMappingTypeDiscovererTests.csproj
+++ b/Validation/ConventionMappingTypeDiscovererTests/ConventionMappingTypeDiscovererTests.csproj
@@ -8,7 +8,7 @@
 <ItemGroup>
   <PackageReference Include="NUnit" Version="3.12.0" />
   <PackageReference Include="NUnit.Extension.DependencyInjection" Version="0.6.0" />
-  <PackageReference Include="NUnit.Extension.DependencyInjection.Unity" Version="0.6.0" />
+  <PackageReference Include="NUnit.Extension.DependencyInjection.Unity" Version="0.6.1" />
   <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
   <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 </ItemGroup>

--- a/Validation/ConventionMappingTypeDiscovererTests/ConventionMappingTypeDiscovererTests.csproj
+++ b/Validation/ConventionMappingTypeDiscovererTests/ConventionMappingTypeDiscovererTests.csproj
@@ -7,8 +7,8 @@
 
 <ItemGroup>
   <PackageReference Include="NUnit" Version="3.12.0" />
-  <PackageReference Include="NUnit.Extension.DependencyInjection" Version="0.5.0" />
-  <PackageReference Include="NUnit.Extension.DependencyInjection.Unity" Version="0.5.0" />
+  <PackageReference Include="NUnit.Extension.DependencyInjection" Version="0.6.0" />
+  <PackageReference Include="NUnit.Extension.DependencyInjection.Unity" Version="0.6.0" />
   <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
   <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 </ItemGroup>

--- a/Validation/ConventionMappingTypeDiscovererTests/RegistrationTests.cs
+++ b/Validation/ConventionMappingTypeDiscovererTests/RegistrationTests.cs
@@ -8,6 +8,9 @@ namespace ConventionMappingTypeDiscovererTests
   public interface IWillNotHaveARegistration {}
   public class ClassesWithoutAnInterfaceAreNotRegistered {}
 
+  public interface IWillHaveARegistration {}
+  public class WillHaveARegistration : IWillHaveARegistration {}
+  
   [DependencyInjectingTestFixture]
   public class RegistrationTests
   {
@@ -19,15 +22,21 @@ namespace ConventionMappingTypeDiscovererTests
     }
 
     [Test]
-    public void Interfaces_without_matching_implementations_are_registered_as_MappedToType()
+    public void Interfaces_without_matching_implementations_are_not_registered_as_MappedToType()
     {
-      Assert.That(_container.Registrations.Any(r => r.MappedToType == typeof(IWillNotHaveARegistration)), Is.True);
+      Assert.That(
+        _container.Registrations.Any(r => r.MappedToType == typeof(IWillNotHaveARegistration)),
+        Is.False,
+        "Found a registration with a MappedToType for an interface not accompanied by a concrete type.");
     }
 
     [Test]
-    public void Interfaces_without_matching_implementations_are_registered_as_RegisteredType()
+    public void Interfaces_without_matching_implementations_are_not_registered_as_RegisteredType()
     {
-      Assert.That(_container.Registrations.Any(r => r.RegisteredType == typeof(IWillNotHaveARegistration)), Is.True);
+      Assert.That(
+        _container.Registrations.Any(r => r.RegisteredType == typeof(IWillNotHaveARegistration)),
+        Is.False,
+        "Found a registration with a RegisteredType for an interface not accompanied by a concrete type.");
     }
 
     [Test]
@@ -46,5 +55,16 @@ namespace ConventionMappingTypeDiscovererTests
         Is.True);
     }
 
+    [Test]
+    public void Classes_with_matching_interface_are_registered_with_expected_mapping()
+    {
+      Assert.That(
+        _container.Registrations.Any(r =>
+          r.RegisteredType == typeof(IWillHaveARegistration) 
+          && r.MappedToType == typeof(WillHaveARegistration)),
+        Is.True);
+    }
+    
+    
   }
 }

--- a/Validation/IocRegistrarTypeDiscovererTests/IocRegistrarTypeDiscovererTests.csproj
+++ b/Validation/IocRegistrarTypeDiscovererTests/IocRegistrarTypeDiscovererTests.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit.Extension.DependencyInjection" Version="0.5.0" />
-    <PackageReference Include="NUnit.Extension.DependencyInjection.Unity" Version="0.5.0" />
+    <PackageReference Include="NUnit.Extension.DependencyInjection" Version="0.6.0" />
+    <PackageReference Include="NUnit.Extension.DependencyInjection.Unity" Version="0.6.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
   </ItemGroup>

--- a/Validation/IocRegistrarTypeDiscovererTests/IocRegistrarTypeDiscovererTests.csproj
+++ b/Validation/IocRegistrarTypeDiscovererTests/IocRegistrarTypeDiscovererTests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit.Extension.DependencyInjection" Version="0.6.0" />
-    <PackageReference Include="NUnit.Extension.DependencyInjection.Unity" Version="0.6.0" />
+    <PackageReference Include="NUnit.Extension.DependencyInjection.Unity" Version="0.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
   </ItemGroup>

--- a/Validation/ManualRegistrarTypeDiscovererTests/ManualRegistrarTypeDiscovererTests.csproj
+++ b/Validation/ManualRegistrarTypeDiscovererTests/ManualRegistrarTypeDiscovererTests.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit.Extension.DependencyInjection" Version="0.5.0" />
-    <PackageReference Include="NUnit.Extension.DependencyInjection.Unity" Version="0.5.0" />
+    <PackageReference Include="NUnit.Extension.DependencyInjection" Version="0.6.0" />
+    <PackageReference Include="NUnit.Extension.DependencyInjection.Unity" Version="0.6.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
   </ItemGroup>

--- a/Validation/ManualRegistrarTypeDiscovererTests/ManualRegistrarTypeDiscovererTests.csproj
+++ b/Validation/ManualRegistrarTypeDiscovererTests/ManualRegistrarTypeDiscovererTests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit.Extension.DependencyInjection" Version="0.6.0" />
-    <PackageReference Include="NUnit.Extension.DependencyInjection.Unity" Version="0.6.0" />
+    <PackageReference Include="NUnit.Extension.DependencyInjection.Unity" Version="0.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
   </ItemGroup>


### PR DESCRIPTION
Order of interfaces and concrete types resulted in empty interface registrations overriding the correct registration.